### PR TITLE
Force arguments early in the plumber process

### DIFF
--- a/R/pr-predict.R
+++ b/R/pr-predict.R
@@ -36,7 +36,7 @@ vetiver_pr_predict <- function(pr,
                                path = "/predict",
                                debug = interactive(),
                                ...) {
-    # force arguments early
+    # `force()` all `...` arguments early; https://github.com/tidymodels/vetiver/pull/20
     rlang::list2(...)
 
     handler_startup(vetiver_model)


### PR DESCRIPTION
The plumber handler may not run until many R ticks later. Example: (line 50 only uses `...` once the handler is called)

https://github.com/tidymodels/vetiver/blob/82cfa07b9bd6fb66e89997853fffa086e55de10c/R/pr-handlers.R#L38-L54

To counter having lazy evaluated values being altered after submission, it is best to force the evaluation of the args.  Typically, this can be done with `force()` or `list(...)`. Since rlang is already included, I chose `rlang::list2(...)`.

This change makes the forced evaluation for every handler, not just `handler_predict.lm()`

----------------------------

tl/dr; I'd rather safe guard and use consistent behavior vs being able to leverage odd lazy evaluation behavior.