### PR TITLE
Update mlr3 support to use new examples

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # vetiver (development version)
 
+* Updated to new datasets in mlr3 examples (#315).
+
 # vetiver 0.2.7
 
 * Updated to support all versions of xgboost (#306).

--- a/inst/penguins_Learner.R
+++ b/inst/penguins_Learner.R
@@ -2,12 +2,12 @@ library(mlr3)
 library(vetiver)
 library(plumber)
 
-task = tsk("pima")
-learner = lrn("classif.rpart")
+task <- tsk("penguins")
+learner <- lrn("classif.rpart")
 
 learner$train(task)
 
-v <- vetiver_model(learner, "pima_rpart")
+v <- vetiver_model(learner, "penguins_rpart")
 v
 
 pr() |>
@@ -19,8 +19,8 @@ library(plumber)
 library(vetiver)
 library(tibble)
 
-task = tsk("pima")
-newdata = as_tibble(task$data())[, task$feature_names]
+task <- tsk("penguins")
+newdata <- as_tibble(task$data())[, task$feature_names]
 
 endpoint <- vetiver_endpoint("http://127.0.0.1:8088/predict")
 predict(endpoint, newdata)

--- a/tests/testthat/_snaps/mlr3.md
+++ b/tests/testthat/_snaps/mlr3.md
@@ -4,8 +4,8 @@
       v
     Output
       
-      -- rpart_pima - <LearnerClassifRpart> model for deployment 
-      A mlr3 classif.rpart learner using 8 features
+      -- rpart_penguins - <LearnerClassifRpart> model for deployment 
+      A mlr3 classif.rpart learner using 7 features
 
 # create plumber.R for mlr3
 
@@ -25,7 +25,7 @@
           library(rpart)
       }
       b <- board_folder(path = "<redacted>")
-      v <- vetiver_pin_read(b, "rpart_pima")
+      v <- vetiver_pin_read(b, "rpart_penguins")
       
       #* @plumber
       function(pr) {

--- a/tests/testthat/_snaps/sagemaker.md
+++ b/tests/testthat/_snaps/sagemaker.md
@@ -42,6 +42,7 @@
         libsodium-dev \
         libssl-dev \
         libuv1-dev \
+        libx11-dev \
         make \
         zlib1g-dev \
         && apt-get clean

--- a/tests/testthat/_snaps/sagemaker.md
+++ b/tests/testthat/_snaps/sagemaker.md
@@ -36,11 +36,12 @@
       ENV RENV_CONFIG_REPOS_OVERRIDE https://packagemanager.rstudio.com/cran/latest
       
       RUN apt-get update -qq && apt-get install -y --no-install-recommends \
+        cmake \
         libcurl4-openssl-dev \
         libicu-dev \
         libsodium-dev \
         libssl-dev \
-        libx11-dev \
+        libuv1-dev \
         make \
         zlib1g-dev \
         && apt-get clean

--- a/tests/testthat/_snaps/write-docker.md
+++ b/tests/testthat/_snaps/write-docker.md
@@ -9,11 +9,12 @@
       ENV RENV_CONFIG_REPOS_OVERRIDE https://packagemanager.rstudio.com/cran/latest
       
       RUN apt-get update -qq && apt-get install -y --no-install-recommends \
+        cmake \
         libcurl4-openssl-dev \
         libicu-dev \
         libsodium-dev \
         libssl-dev \
-        libx11-dev \
+        libuv1-dev \
         make \
         zlib1g-dev \
         && apt-get clean
@@ -36,11 +37,12 @@
       ENV RENV_CONFIG_REPOS_OVERRIDE https://packagemanager.rstudio.com/cran/latest
       
       RUN apt-get update -qq && apt-get install -y --no-install-recommends \
+        cmake \
         libcurl4-openssl-dev \
         libicu-dev \
         libsodium-dev \
         libssl-dev \
-        libx11-dev \
+        libuv1-dev \
         make \
         zlib1g-dev \
         && apt-get clean
@@ -62,11 +64,12 @@
       FROM rocker/r-ver:<r_version>
       
       RUN apt-get update -qq && apt-get install -y --no-install-recommends \
+        cmake \
         libcurl4-openssl-dev \
         libicu-dev \
         libsodium-dev \
         libssl-dev \
-        libx11-dev \
+        libuv1-dev \
         make \
         zlib1g-dev \
         && apt-get clean
@@ -89,11 +92,12 @@
       ENV RENV_CONFIG_REPOS_OVERRIDE https://packagemanager.rstudio.com/cran/latest
       
       RUN apt-get update -qq && apt-get install -y --no-install-recommends \
+        cmake \
         libcurl4-openssl-dev \
         libicu-dev \
         libsodium-dev \
         libssl-dev \
-        libx11-dev \
+        libuv1-dev \
         make \
         zlib1g-dev \
         && apt-get clean
@@ -116,11 +120,12 @@
       ENV RENV_CONFIG_REPOS_OVERRIDE https://packagemanager.rstudio.com/cran/latest
       
       RUN apt-get update -qq && apt-get install -y --no-install-recommends \
+        cmake \
         libcurl4-openssl-dev \
         libicu-dev \
         libsodium-dev \
         libssl-dev \
-        libx11-dev \
+        libuv1-dev \
         make \
         zlib1g-dev \
         && apt-get clean
@@ -161,11 +166,12 @@
       FROM rocker/r-ver:<r_version>
       
       RUN apt-get update -qq && apt-get install -y --no-install-recommends \
+        cmake \
         libcurl4-openssl-dev \
         libicu-dev \
         libsodium-dev \
         libssl-dev \
-        libx11-dev \
+        libuv1-dev \
         make \
         zlib1g-dev \
         && apt-get clean

--- a/tests/testthat/_snaps/write-docker.md
+++ b/tests/testthat/_snaps/write-docker.md
@@ -15,6 +15,7 @@
         libsodium-dev \
         libssl-dev \
         libuv1-dev \
+        libx11-dev \
         make \
         zlib1g-dev \
         && apt-get clean
@@ -43,6 +44,7 @@
         libsodium-dev \
         libssl-dev \
         libuv1-dev \
+        libx11-dev \
         make \
         zlib1g-dev \
         && apt-get clean
@@ -70,6 +72,7 @@
         libsodium-dev \
         libssl-dev \
         libuv1-dev \
+        libx11-dev \
         make \
         zlib1g-dev \
         && apt-get clean
@@ -98,6 +101,7 @@
         libsodium-dev \
         libssl-dev \
         libuv1-dev \
+        libx11-dev \
         make \
         zlib1g-dev \
         && apt-get clean
@@ -126,6 +130,7 @@
         libsodium-dev \
         libssl-dev \
         libuv1-dev \
+        libx11-dev \
         make \
         zlib1g-dev \
         && apt-get clean
@@ -172,6 +177,7 @@
         libsodium-dev \
         libssl-dev \
         libuv1-dev \
+        libx11-dev \
         make \
         zlib1g-dev \
         && apt-get clean

--- a/tests/testthat/test-mlr3.R
+++ b/tests/testthat/test-mlr3.R
@@ -1,36 +1,39 @@
 skip_if_not_installed("mlr3")
 
 test_that("mlr3 learner description can be printed", {
-  task = mlr3::tsk("pima")
-  learner = mlr3::lrn("classif.rpart")
+  task <- mlr3::tsk("penguins")
+  learner <- mlr3::lrn("classif.rpart")
   learner$train(task)
-  v <- vetiver_model(learner, "rpart_pima")
+  v <- vetiver_model(learner, "rpart_penguins")
   expect_snapshot(v)
 })
 
 test_that("mlr3 learners can be pinned", {
-  task = mlr3::tsk("pima")
-  learner = mlr3::lrn("classif.rpart")
+  task <- mlr3::tsk("penguins")
+  learner <- mlr3::lrn("classif.rpart")
   learner$train(task)
 
-  v <- vetiver_model(learner, "rpart_pima")
+  v <- vetiver_model(learner, "rpart_penguins")
   b <- board_temp()
   vetiver_pin_write(b, v)
-  pinned <- pin_read(b, "rpart_pima")
+  pinned <- pin_read(b, "rpart_penguins")
 
   expect_length(pinned, 2)
   expect_equal(class(pinned$model)[1], "LearnerClassifRpart")
   expect_equal(nrow(pinned$prototype), 0)
   expect_equal(names(pinned$prototype), task$feature_names)
-  expect_equal(pin_meta(b, "rpart_pima")$user$required_pkgs, c("mlr3", "rpart"))
+  expect_equal(
+    pin_meta(b, "rpart_penguins")$user$required_pkgs,
+    c("mlr3", "rpart")
+  )
 })
 
 test_that("learners from mlr3learners can be pinned", {
   skip_if_not_installed("mlr3learners")
   skip_if_not_installed("xgboost")
 
-  task = mlr3::tsk("spam")
-  learner = mlr3learners::LearnerClassifXgboost$new()
+  task <- mlr3::tsk("spam")
+  learner <- mlr3learners::LearnerClassifXgboost$new()
   learner$train(task)
 
   v <- vetiver_model(learner, "logreg_spam")
@@ -52,15 +55,15 @@ test_that("learners from mlr3learners can be pinned", {
 test_that("create plumber.R for mlr3", {
   skip_on_cran()
 
-  task = mlr3::tsk("pima")
-  learner = mlr3::lrn("classif.rpart")
+  task <- mlr3::tsk("penguins")
+  learner <- mlr3::lrn("classif.rpart")
   learner$train(task)
 
-  v <- vetiver_model(learner, "rpart_pima")
+  v <- vetiver_model(learner, "rpart_penguins")
   b <- board_folder(path = tmp_dir)
   vetiver_pin_write(b, v)
   tmp <- tempfile()
-  vetiver_write_plumber(b, "rpart_pima", file = tmp)
+  vetiver_write_plumber(b, "rpart_penguins", file = tmp)
   expect_snapshot(
     cat(readr::read_lines(tmp), sep = "\n"),
     transform = redact_vetiver


### PR DESCRIPTION
I got a message from CRAN that the PimaIndiansDiabetes from the mlbench package had to get taken down. We used that here via mlr3 and `task("pima")`, so let's try switching all those out.

I will have to do a CRAN release for this.